### PR TITLE
Fix ARG order in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 ARG DOCKER_HUB="docker.io"
+ARG NGINX_VERSION="1.17.6"
 
 FROM $DOCKER_HUB/library/node:10.10-alpine as build
 
@@ -12,7 +13,6 @@ RUN echo "registry = \"$NPM_REGISTRY\"" > /workspace/.npmrc                     
     npm install                                                                          && \
     npm run build
 
-ARG NGINX_VERSION="1.17.6"
 FROM $DOCKER_HUB/library/nginx:$NGINX_VERSION AS runtime
 
 


### PR DESCRIPTION
See https://github.com/docker/cli/issues/2762#issuecomment-701703538. As per Docker documentation:

> FROM instructions support variables that are declared by any ARG instructions that occur before the first FROM