### PR TITLE
adding single quote rule for linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,8 +34,15 @@
             "prefix": "app",
             "style": "camelCase",
             "type": "attribute"
-          }
-        ],
+          
+          }],
+          "@typescript-eslint/quotes": [
+            "error",
+            "single",
+            {
+              "allowTemplateLiterals": true
+            }
+          ],
         "@angular-eslint/no-empty-lifecycle-method":"off"
       }
     },
@@ -45,8 +52,7 @@
       ],
       "extends": [
         "plugin:@angular-eslint/template/recommended"
-      ],
-      "rules": {}
+      ]
     }
   ]
 }


### PR DESCRIPTION
@arey 

I noticed that after editing a file from ( single quotes to double quotes ). eslint was unable to find the error in that file. Using the rule that i have introduced in the code. It will amend double quote to single quote.