### PR TITLE
display only when response from API was received

### DIFF
--- a/src/app/owners/owner-list/owner-list.component.html
+++ b/src/app/owners/owner-list/owner-list.component.html
@@ -69,7 +69,7 @@
         </tbody>
       </table>
       <div>
-        <button class="btn btn-default" (click)="addOwner()">Add Owner</button>
+        <button *ngIf="isOwnersDataReceived" class="btn btn-default" (click)="addOwner()">Add Owner</button>
       </div>
     </div>
   </div>

--- a/src/app/owners/owner-list/owner-list.component.ts
+++ b/src/app/owners/owner-list/owner-list.component.ts
@@ -24,6 +24,7 @@ import {Component, OnInit} from '@angular/core';
 import {OwnerService} from '../owner.service';
 import {Owner} from '../owner';
 import {Router} from '@angular/router';
+import { finalize } from 'rxjs/operators';
 
 @Component({
   selector: 'app-owner-list',
@@ -35,13 +36,18 @@ export class OwnerListComponent implements OnInit {
   lastName: string;
   owners: Owner[];
   listOfOwnersWithLastName: Owner[];
+  isOwnersDataReceived: boolean = false;
 
   constructor(private router: Router, private ownerService: OwnerService) {
 
   }
 
   ngOnInit() {
-    this.ownerService.getOwners().subscribe(
+    this.ownerService.getOwners().pipe(
+      finalize(() => {
+        this.isOwnersDataReceived = true;
+      })
+    ).subscribe(
       owners => this.owners = owners,
       error => this.errorMessage = error as any);
   }

--- a/src/app/pettypes/pettype-list/pettype-list.component.html
+++ b/src/app/pettypes/pettype-list/pettype-list.component.html
@@ -44,8 +44,8 @@
       <app-pettype-add (newPetType)="onNewPettype($event)">...</app-pettype-add>
     </div>
     <div>
-      <button class="btn btn-default" (click)="gotoHome()">Home</button>
-      <button class="btn btn-default" (click)="showAddPettypeComponent()"> Add </button>
+      <button *ngIf="isPetTypesDataReceived" class="btn btn-default" (click)="gotoHome()">Home</button>
+      <button *ngIf="isPetTypesDataReceived" class="btn btn-default" (click)="showAddPettypeComponent()"> Add </button>
     </div>
   </div>
 </div>

--- a/src/app/pettypes/pettype-list/pettype-list.component.ts
+++ b/src/app/pettypes/pettype-list/pettype-list.component.ts
@@ -3,6 +3,7 @@ import {PetType} from '../pettype';
 import {Router} from '@angular/router';
 import {PetTypeService} from '../pettype.service';
 import {Specialty} from '../../specialties/specialty';
+import { finalize } from 'rxjs/operators';
 
 @Component({
   selector: 'app-pettype-list',
@@ -13,6 +14,7 @@ export class PettypeListComponent implements OnInit {
   pettypes: PetType[];
   errorMessage: string;
   responseStatus: number;
+  isPetTypesDataReceived: boolean = false;
   isInsert = false;
 
   constructor(private pettypeService: PetTypeService, private router: Router) {
@@ -20,10 +22,14 @@ export class PettypeListComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.pettypeService.getPetTypes().subscribe(
+    this.pettypeService.getPetTypes().pipe(
+      finalize(() => {
+        this.isPetTypesDataReceived = true;
+      })
+    ).subscribe(
       pettypes => this.pettypes = pettypes,
       error => this.errorMessage = error as any
-    );
+      );
   }
 
   deletePettype(pettype: PetType) {

--- a/src/app/specialties/specialty-list/specialty-list.component.html
+++ b/src/app/specialties/specialty-list/specialty-list.component.html
@@ -44,8 +44,8 @@
       <app-specialty-add (newSpeciality)="onNewSpecialty($event)">...</app-specialty-add>
     </div>
     <div>
-      <button class="btn btn-default" (click)="gotoHome()">Home</button>
-      <button class="btn btn-default" (click)="showAddSpecialtyComponent()"> Add </button>
+      <button *ngIf="isSpecialitiesDataReceived" class="btn btn-default" (click)="gotoHome()">Home</button>
+      <button *ngIf="isSpecialitiesDataReceived" class="btn btn-default" (click)="showAddSpecialtyComponent()"> Add </button>
     </div>
   </div>
 </div>

--- a/src/app/specialties/specialty-list/specialty-list.component.ts
+++ b/src/app/specialties/specialty-list/specialty-list.component.ts
@@ -24,6 +24,7 @@ import {Component, OnInit} from '@angular/core';
 import {Specialty} from '../specialty';
 import {SpecialtyService} from '../specialty.service';
 import {Router} from '@angular/router';
+import { finalize } from 'rxjs/operators';
 
 @Component({
   selector: 'app-specialty-list',
@@ -35,13 +36,18 @@ export class SpecialtyListComponent implements OnInit {
   errorMessage: string;
   responseStatus: number;
   isInsert = false;
+  isSpecialitiesDataReceived: boolean = false;
 
   constructor(private specService: SpecialtyService, private router: Router) {
     this.specialties = [];
   }
 
   ngOnInit() {
-    this.specService.getSpecialties().subscribe(
+    this.specService.getSpecialties().pipe(
+      finalize(() => {
+        this.isSpecialitiesDataReceived = true;
+      })
+    ).subscribe(
       specialties => this.specialties = specialties,
       error => this.errorMessage = error as any);
   }

--- a/src/app/vets/vet-list/vet-list.component.html
+++ b/src/app/vets/vet-list/vet-list.component.html
@@ -48,7 +48,7 @@
       </tbody>
     </table>
     <div>
-      <button class="btn btn-default" (click)="gotoHome()">Home</button>
-      <button class="btn btn-default" (click)="addVet()">Add Vet</button>
+      <button *ngIf="isVetDataReceived" class="btn btn-default" (click)="gotoHome()">Home</button>
+      <button *ngIf="isVetDataReceived" class="btn btn-default" (click)="addVet()">Add Vet</button>
     </div>
   </div>

--- a/src/app/vets/vet-list/vet-list.component.ts
+++ b/src/app/vets/vet-list/vet-list.component.ts
@@ -24,6 +24,7 @@ import {Component, OnInit} from '@angular/core';
 import {Vet} from '../vet';
 import {VetService} from '../vet.service';
 import {Router} from '@angular/router';
+import { finalize } from 'rxjs/operators';
 
 @Component({
   selector: 'app-vet-list',
@@ -34,13 +35,18 @@ export class VetListComponent implements OnInit {
   vets: Vet[];
   errorMessage: string;
   responseStatus: number;
+  isVetDataReceived: boolean = false;
 
   constructor(private vetService: VetService, private router: Router) {
     this.vets = [];
   }
 
   ngOnInit() {
-    this.vetService.getVets().subscribe(
+    this.vetService.getVets().pipe(
+      finalize(() => {
+        this.isVetDataReceived = true;
+      })
+    ).subscribe(
       vets => this.vets = vets,
       error => this.errorMessage = error as any);
   }


### PR DESCRIPTION
### Purpose

Only show the "Home" and "Add" buttons on the list components after the data from the backend has been received. This will ensure that the "Home" and "Add" buttons will be displayed at their final position on the page, instead of jumping down after the table data has been fetched.

Issue https://github.com/spring-petclinic/spring-petclinic-angular/issues/121