### PR TITLE
Update input validation rules and messages in HTML templates to be aligned with the openAPI definition

### DIFF
--- a/src/app/owners/owner-add/owner-add.component.html
+++ b/src/app/owners/owner-add/owner-add.component.html
@@ -18,65 +18,72 @@
 
 
 
-<div class="container-fluid">
-  <div class="container xd-container">
-    <h2>
-      New Owner
-    </h2>
-    <form (ngSubmit)="onSubmit(ownerForm.value)" #ownerForm="ngForm" class="form-horizontal">
-      <div class="form-group" hidden="true">
-        <input type="text" hidden="true" class="form-control" id="id" [(ngModel)]="owner.id" name="id"/>
-      </div>
-      <div class="form-group has-feedback" [class.has-success]="firstName.dirty && firstName.valid" [class.has-error]="firstName.dirty &&  !firstName.valid">
-        <label for="firstName" class="col-sm-2 control-label">First Name</label>
-        <div class="col-sm-10">
-          <input type="text" class="form-control" id="firstName" [(ngModel)]="owner.firstName" minlength="2" required name="firstName" #firstName="ngModel"/>
-          <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="firstName.valid" [class.glyphicon-remove]="!firstName.valid" aria-hidden="true"></span>
-          <span class="help-block" *ngIf="firstName.dirty && firstName.hasError('required')">First name is required</span>
-          <span class="help-block" *ngIf="firstName.dirty && firstName.hasError('minlength')">First name must be at least 2 characters long</span>
+  <div class="container-fluid">
+    <div class="container xd-container">
+      <h2>
+        New Owner
+      </h2>
+      <form (ngSubmit)="onSubmit(ownerForm.value)" #ownerForm="ngForm" class="form-horizontal">
+        <div class="form-group" hidden="true">
+          <input type="text" hidden="true" class="form-control" id="id" [(ngModel)]="owner.id" name="id"/>
         </div>
-      </div>
-      <div class="form-group has-feedback" [class.has-success]="lastName.dirty && lastName.valid" [class.has-error]="lastName.dirty && !lastName.valid">
-        <label for="lastName" class="col-sm-2 control-label">Last Name</label>
-        <div class="col-sm-10">
-          <input type="text" class="form-control" id="lastName" [(ngModel)]="owner.lastName" name="lastName" minlength="2" required #lastName="ngModel"/>
-          <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="lastName.valid" [class.glyphicon-remove]="!lastName.valid" aria-hidden="true"></span>
-          <span class="help-block" *ngIf="lastName.dirty && lastName.hasError('required')">Last name is required</span>
-          <span class="help-block" *ngIf="lastName.dirty && lastName.hasError('minlength')">Last name must be at least 2 characters long</span>
+        <div class="form-group has-feedback" [class.has-success]="firstName.dirty && firstName.valid" [class.has-error]="firstName.dirty &&  !firstName.valid">
+          <label for="firstName" class="col-sm-2 control-label">First Name</label>
+          <div class="col-sm-10">
+            <input type="text" class="form-control" id="firstName" [(ngModel)]="owner.firstName" minlength="1" maxlength="30" pattern="^[a-zA-Z]*$" required name="firstName" #firstName="ngModel"/>
+            <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="firstName.valid" [class.glyphicon-remove]="!firstName.valid" aria-hidden="true"></span>
+            <span class="help-block" *ngIf="firstName.dirty && firstName.hasError('required')">First name is required</span>
+            <span class="help-block" *ngIf="firstName.dirty && firstName.hasError('minlength')">First name must be at least 1 characters long</span>
+            <span class="help-block" *ngIf="firstName.dirty && firstName.hasError('maxlength')">First name may be at most 30 characters long</span>
+            <span class="help-block" *ngIf="firstName.dirty && firstName.hasError('pattern')">First name must consist of letters only</span>
+         </div>
         </div>
-      </div>
-      <div class="form-group has-feedback" [class.has-success]="address.dirty && address.valid" [class.has-error]="address.dirty && !address.valid">
-        <label for="address" class="col-sm-2 control-label">Address</label>
-        <div class="col-sm-10">
-          <input type="text" class="form-control" id="address" [(ngModel)]="owner.address" name="address" required #address="ngModel"/>
-          <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="address.valid" [class.glyphicon-remove]="!address.valid" aria-hidden="true"></span>
-          <span class="help-block" *ngIf="address.dirty && address.hasError('required')">Address is required</span>
+        <div class="form-group has-feedback" [class.has-success]="lastName.dirty && lastName.valid" [class.has-error]="lastName.dirty && !lastName.valid">
+          <label for="lastName" class="col-sm-2 control-label">Last Name</label>
+          <div class="col-sm-10">
+            <input type="text" class="form-control" id="lastName" [(ngModel)]="owner.lastName" name="lastName" minlength="1" maxlength="30" pattern="^[a-zA-Z]*$" required #lastName="ngModel"/>
+            <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="lastName.valid" [class.glyphicon-remove]="!lastName.valid" aria-hidden="true"></span>
+            <span class="help-block" *ngIf="lastName.dirty && lastName.hasError('required')">Last name is required</span>
+            <span class="help-block" *ngIf="lastName.dirty && lastName.hasError('minlength')">Last name must be at least 1 characters long</span>
+            <span class="help-block" *ngIf="lastName.dirty && lastName.hasError('maxlength')">Last name may be at most 30 characters long</span>
+            <span class="help-block" *ngIf="lastName.dirty && lastName.hasError('pattern')">Last name must consist of letters only</span>
+         </div>
         </div>
-      </div>
-      <div class="form-group has-feedback" [class.has-success]="city.dirty && city.valid" [class.has-error]="city.dirty && !city.valid">
-        <label for="city" class="col-sm-2 control-label">City</label>
-        <div class="col-sm-10">
-          <input type="text" class="form-control" id="city" [(ngModel)]="owner.city" name="city" required #city="ngModel"/>
-          <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="city.valid" [class.glyphicon-remove]="!city.valid" aria-hidden="true"></span>
-          <span class="help-block" *ngIf="city.dirty && city.hasError('required')">City is required</span>
+        <div class="form-group has-feedback" [class.has-success]="address.dirty && address.valid" [class.has-error]="address.dirty && !address.valid">
+          <label for="address" class="col-sm-2 control-label">Address</label>
+          <div class="col-sm-10">
+            <input type="text" class="form-control" id="address" [(ngModel)]="owner.address" name="address" maxlength="255"  required #address="ngModel"/>
+            <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="address.valid" [class.glyphicon-remove]="!address.valid" aria-hidden="true"></span>
+            <span class="help-block" *ngIf="address.dirty && address.hasError('required')">Address is required</span>
+            <span class="help-block" *ngIf="address.dirty && address.hasError('maxlength')">Address may be at most 255 characters long</span>
+         </div>
         </div>
-      </div>
-      <div class="form-group has-feedback" [class.has-success]="telephone.dirty && telephone.valid" [class.has-error]="telephone.dirty && !telephone.valid">
-        <label for="telephone" class="col-sm-2 control-label">Telephone</label>
-        <div class="col-sm-10">
-          <input type="text" class="form-control" id="telephone" [(ngModel)]="owner.telephone" name="telephone" required maxlength="10" pattern="^[0-9]{0,10}$" #telephone="ngModel"/>
-          <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="telephone.valid" [class.glyphicon-remove]="!telephone.valid" aria-hidden="true"></span>
-          <span class="help-block" *ngIf="telephone.dirty && telephone.hasError('required')">Phone number is required</span>
-          <span class="help-block" *ngIf="telephone.dirty && telephone.hasError('maxlength')">Phone number cannot be more than 10 digits long</span>
-          <span class="help-block" *ngIf="telephone.dirty && telephone.hasError('pattern')" >Phone number only accept digits</span>
+        <div class="form-group has-feedback" [class.has-success]="city.dirty && city.valid" [class.has-error]="city.dirty && !city.valid">
+          <label for="city" class="col-sm-2 control-label">City</label>
+          <div class="col-sm-10">
+            <input type="text" class="form-control" id="city" [(ngModel)]="owner.city" name="city" maxlength="80" required #city="ngModel"/>
+            <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="city.valid" [class.glyphicon-remove]="!city.valid" aria-hidden="true"></span>
+            <span class="help-block" *ngIf="city.dirty && city.hasError('required')">City is required</span>
+            <span class="help-block" *ngIf="city.dirty && city.hasError('maxlength')">City may be at most 80 characters long</span>
+          </div>
         </div>
-      </div>
-      <div class="form-group">
-        <div class="col-sm-offset-2 col-sm-10">
-          <button class="btn btn-default" type="button" (click)="gotoOwnersList()">Back</button>
-          <button class="btn btn-default" type="submit" [disabled]="!ownerForm.valid">Add Owner</button>
+        <div class="form-group has-feedback" [class.has-success]="telephone.dirty && telephone.valid" [class.has-error]="telephone.dirty && !telephone.valid">
+          <label for="telephone" class="col-sm-2 control-label">Telephone</label>
+          <div class="col-sm-10">
+            <input type="text" class="form-control" id="telephone" [(ngModel)]="owner.telephone" name="telephone" required minlength="1" maxlength="20" pattern="^[0-9]*$" #telephone="ngModel"/>
+            <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="telephone.valid" [class.glyphicon-remove]="!telephone.valid" aria-hidden="true"></span>
+            <span class="help-block" *ngIf="telephone.dirty && telephone.hasError('required')">Phone number is required</span>
+            <span class="help-block" *ngIf="telephone.dirty && telephone.hasError('maxlength')">Phone number cannot be more than 20 digits long</span>
+            <span class="help-block" *ngIf="telephone.dirty && telephone.hasError('pattern')" >Phone number only accept digits</span>
+          </div>
         </div>
-      </div>
-    </form>
+        <div class="form-group">
+          <div class="col-sm-offset-2 col-sm-10">
+            <button class="btn btn-default" type="button" (click)="gotoOwnersList()">Back</button>
+            <button class="btn btn-default" type="submit" [disabled]="!ownerForm.valid">Add Owner</button>
+          </div>
+        </div>
+      </form>
+    </div>
   </div>
-</div>
+  

--- a/src/app/owners/owner-edit/owner-edit.component.html
+++ b/src/app/owners/owner-edit/owner-edit.component.html
@@ -16,211 +16,254 @@
   ~  */
   -->
 
-<div class="container-fluid">
-  <div class="container xd-container">
-    <h2>Edit Owner</h2>
-    <div *ngIf="errorMessage" class="alert alert-danger">
-      {{ errorMessage }}
+  <div class="container-fluid">
+    <div class="container xd-container">
+      <h2>Edit Owner</h2>
+      <div *ngIf="errorMessage" class="alert alert-danger">
+        {{ errorMessage }}
+      </div>
+      <form
+        (ngSubmit)="onSubmit(ownerForm.value)"
+        #ownerForm="ngForm"
+        class="form-horizontal"
+      >
+        <div class="form-group" hidden="true">
+          <input
+            type="text"
+            hidden="true"
+            class="form-control"
+            id="id"
+            [(ngModel)]="owner.id"
+            name="id"
+          />
+        </div>
+        <div
+          class="form-group has-feedback"
+          [class.has-success]="firstName.valid"
+          [class.has-error]="!firstName.valid"
+        >
+          <label for="firstName" class="col-sm-2 control-label">First Name</label>
+          <div class="col-sm-10">
+            <input
+              type="text"
+              class="form-control"
+              id="firstName"
+              [(ngModel)]="owner.firstName"
+              minlength="1"
+              maxlength="30" 
+              pattern="^[a-zA-Z]*$"
+              required
+              name="firstName"
+              #firstName="ngModel"
+            />
+            <span
+              class="glyphicon form-control-feedback"
+              [class.glyphicon-ok]="firstName.valid"
+              [class.glyphicon-remove]="!firstName.valid"
+              aria-hidden="true"
+            ></span>
+            <span
+              class="help-block"
+              *ngIf="firstName.dirty && firstName.hasError('required')"
+              >First name is required</span
+            >
+            <span
+              class="help-block"
+              *ngIf="firstName.dirty && firstName.hasError('minlength')"
+              >First name must be at least 1 characters long</span
+            >
+            <span
+            class="help-block"
+            *ngIf="firstName.dirty && firstName.hasError('maxlength')"
+            >First name may be at most 30 characters long</span
+          >
+          <span
+          class="help-block"
+          *ngIf="firstName.dirty && firstName.hasError('pattern')"
+          >First name must consist of letters only</span
+        >
+          </div>
+        </div>
+        <div
+          class="form-group has-feedback"
+          [class.has-success]="lastName.valid"
+          [class.has-error]="!lastName.valid"
+        >
+          <label for="lastName" class="col-sm-2 control-label">Last Name</label>
+          <div class="col-sm-10">
+            <input
+              type="text"
+              class="form-control"
+              id="lastName"
+              [(ngModel)]="owner.lastName"
+              name="lastName"
+              minlength="1"
+              maxlength="30" 
+              pattern="^[a-zA-Z]*$"
+              required
+              #lastName="ngModel"
+            />
+            <span
+              class="glyphicon form-control-feedback"
+              [class.glyphicon-ok]="lastName.valid"
+              [class.glyphicon-remove]="!lastName.valid"
+              aria-hidden="true"
+            ></span>
+            <span
+              class="help-block"
+              *ngIf="lastName.dirty && lastName.hasError('required')"
+              >Last name is required</span
+            >
+            <span
+              class="help-block"
+              *ngIf="lastName.dirty && lastName.hasError('minlength')"
+              >Last name must be at least 1 characters long</span
+            >
+            <span
+            class="help-block"
+            *ngIf="lastName.dirty && lastName.hasError('maxlength')"
+            >Last name may be at most 30 characters long</span
+          >
+          <span
+          class="help-block"
+          *ngIf="lastName.dirty && lastName.hasError('pattern')"
+          >Last name must consist of letters only</span
+        >
+          </div>
+        </div>
+        <div
+          class="form-group has-feedback"
+          [class.has-success]="address.valid"
+          [class.has-error]="!address.valid"
+        >
+          <label for="address" class="col-sm-2 control-label">Address</label>
+          <div class="col-sm-10">
+            <input
+              type="text"
+              class="form-control"
+              id="address"
+              [(ngModel)]="owner.address"
+              name="address"
+              maxlength="255"  
+              required
+              #address="ngModel"
+            />
+            <span
+              class="glyphicon form-control-feedback"
+              [class.glyphicon-ok]="address.valid"
+              [class.glyphicon-remove]="!address.valid"
+              aria-hidden="true"
+            ></span>
+            <span
+              class="help-block"
+              *ngIf="address.dirty && address.hasError('required')"
+              >Address is required</span
+            >
+            <span
+            class="help-block"
+            *ngIf="address.dirty && address.hasError('maxlength')"
+            >Address may be at most 255 characters long</span
+          >
+          </div>
+        </div>
+        <div
+          class="form-group has-feedback"
+          [class.has-success]="city.valid"
+          [class.has-error]="!city.valid"
+        >
+          <label for="city" class="col-sm-2 control-label">City</label>
+          <div class="col-sm-10">
+            <input
+              type="text"
+              class="form-control"
+              id="city"
+              [(ngModel)]="owner.city"
+              name="city"
+              maxlength="80" 
+              required
+              #city="ngModel"
+            />
+            <span
+              class="glyphicon form-control-feedback"
+              [class.glyphicon-ok]="city.valid"
+              [class.glyphicon-remove]="!city.valid"
+              aria-hidden="true"
+            ></span>
+            <span
+              class="help-block"
+              *ngIf="city.dirty && city.hasError('required')"
+              >City is required</span
+            >
+            <span
+            class="help-block"
+            *ngIf="city.dirty && city.hasError('maxlength')"
+            >City may be at most 80 characters long</span
+          >
+          </div>
+        </div>
+        <div
+          class="form-group has-feedback"
+          [class.has-success]="telephone.valid"
+          [class.has-error]="!telephone.valid"
+        >
+          <label for="telephone" class="col-sm-2 control-label">Telephone</label>
+          <div class="col-sm-10">
+            <input
+              type="text"
+              class="form-control"
+              id="telephone"
+              [(ngModel)]="owner.telephone"
+              name="telephone"
+              required
+              minlength="1"
+              maxlength="20"
+              pattern="^[0-9]*$"
+              #telephone="ngModel"
+            />
+            <span
+              class="glyphicon form-control-feedback"
+              [class.glyphicon-ok]="telephone.valid"
+              [class.glyphicon-remove]="!telephone.valid"
+              aria-hidden="true"
+            ></span>
+            <span
+              class="help-block"
+              *ngIf="telephone.dirty && telephone.hasError('required')"
+              >Phone number is required</span
+            >
+            <span
+            class="help-block"
+            *ngIf="telephone.dirty && telephone.hasError('minlength')"
+            >Phone number must be at least one digit long</span
+          >
+            <span
+              class="help-block"
+              *ngIf="telephone.dirty && telephone.hasError('maxlength')"
+              >Phone number cannot be more than 20 digits long</span
+            >
+            <span
+              class="help-block"
+              *ngIf="telephone.dirty && telephone.hasError('pattern')"
+              >Phone number only accept digits</span
+            >
+          </div>
+        </div>
+  
+        <div class="form-group">
+          <div class="col-sm-offset-2 col-sm-10">
+            <button class="btn btn-default" (click)="gotoOwnerDetail(owner)">
+              Back
+            </button>
+            <button
+              type="submit"
+              [disabled]="!ownerForm.valid"
+              class="btn btn-default"
+            >
+              Update Owner
+            </button>
+          </div>
+        </div>
+      </form>
     </div>
-    <form
-      (ngSubmit)="onSubmit(ownerForm.value)"
-      #ownerForm="ngForm"
-      class="form-horizontal"
-    >
-      <div class="form-group" hidden="true">
-        <input
-          type="text"
-          hidden="true"
-          class="form-control"
-          id="id"
-          [(ngModel)]="owner.id"
-          name="id"
-        />
-      </div>
-      <div
-        class="form-group has-feedback"
-        [class.has-success]="firstName.valid"
-        [class.has-error]="!firstName.valid"
-      >
-        <label for="firstName" class="col-sm-2 control-label">First Name</label>
-        <div class="col-sm-10">
-          <input
-            type="text"
-            class="form-control"
-            id="firstName"
-            [(ngModel)]="owner.firstName"
-            minlength="2"
-            required
-            name="firstName"
-            #firstName="ngModel"
-          />
-          <span
-            class="glyphicon form-control-feedback"
-            [class.glyphicon-ok]="firstName.valid"
-            [class.glyphicon-remove]="!firstName.valid"
-            aria-hidden="true"
-          ></span>
-          <span
-            class="help-block"
-            *ngIf="firstName.dirty && firstName.hasError('required')"
-            >First name is required</span
-          >
-          <span
-            class="help-block"
-            *ngIf="firstName.dirty && firstName.hasError('minlength')"
-            >First name must be at least 2 characters long</span
-          >
-        </div>
-      </div>
-      <div
-        class="form-group has-feedback"
-        [class.has-success]="lastName.valid"
-        [class.has-error]="!lastName.valid"
-      >
-        <label for="lastName" class="col-sm-2 control-label">Last Name</label>
-        <div class="col-sm-10">
-          <input
-            type="text"
-            class="form-control"
-            id="lastName"
-            [(ngModel)]="owner.lastName"
-            name="lastName"
-            minlength="2"
-            required
-            #lastName="ngModel"
-          />
-          <span
-            class="glyphicon form-control-feedback"
-            [class.glyphicon-ok]="lastName.valid"
-            [class.glyphicon-remove]="!lastName.valid"
-            aria-hidden="true"
-          ></span>
-          <span
-            class="help-block"
-            *ngIf="lastName.dirty && lastName.hasError('required')"
-            >Last name is required</span
-          >
-          <span
-            class="help-block"
-            *ngIf="lastName.dirty && lastName.hasError('minlength')"
-            >Last name must be at least 2 characters long</span
-          >
-        </div>
-      </div>
-      <div
-        class="form-group has-feedback"
-        [class.has-success]="address.valid"
-        [class.has-error]="!address.valid"
-      >
-        <label for="address" class="col-sm-2 control-label">Address</label>
-        <div class="col-sm-10">
-          <input
-            type="text"
-            class="form-control"
-            id="address"
-            [(ngModel)]="owner.address"
-            name="address"
-            required
-            #address="ngModel"
-          />
-          <span
-            class="glyphicon form-control-feedback"
-            [class.glyphicon-ok]="address.valid"
-            [class.glyphicon-remove]="!address.valid"
-            aria-hidden="true"
-          ></span>
-          <span
-            class="help-block"
-            *ngIf="address.dirty && address.hasError('required')"
-            >Address is required</span
-          >
-        </div>
-      </div>
-      <div
-        class="form-group has-feedback"
-        [class.has-success]="city.valid"
-        [class.has-error]="!city.valid"
-      >
-        <label for="city" class="col-sm-2 control-label">City</label>
-        <div class="col-sm-10">
-          <input
-            type="text"
-            class="form-control"
-            id="city"
-            [(ngModel)]="owner.city"
-            name="city"
-            required
-            #city="ngModel"
-          />
-          <span
-            class="glyphicon form-control-feedback"
-            [class.glyphicon-ok]="city.valid"
-            [class.glyphicon-remove]="!city.valid"
-            aria-hidden="true"
-          ></span>
-          <span
-            class="help-block"
-            *ngIf="city.dirty && city.hasError('required')"
-            >City is required</span
-          >
-        </div>
-      </div>
-      <div
-        class="form-group has-feedback"
-        [class.has-success]="telephone.valid"
-        [class.has-error]="!telephone.valid"
-      >
-        <label for="telephone" class="col-sm-2 control-label">Telephone</label>
-        <div class="col-sm-10">
-          <input
-            type="text"
-            class="form-control"
-            id="telephone"
-            [(ngModel)]="owner.telephone"
-            name="telephone"
-            required
-            maxlength="10"
-            pattern="^[0-9]{0,10}$"
-            #telephone="ngModel"
-          />
-          <span
-            class="glyphicon form-control-feedback"
-            [class.glyphicon-ok]="telephone.valid"
-            [class.glyphicon-remove]="!telephone.valid"
-            aria-hidden="true"
-          ></span>
-          <span
-            class="help-block"
-            *ngIf="telephone.dirty && telephone.hasError('required')"
-            >Phone number is required</span
-          >
-          <span
-            class="help-block"
-            *ngIf="telephone.dirty && telephone.hasError('maxlength')"
-            >Phone number cannot be more than 10 digits long</span
-          >
-          <span
-            class="help-block"
-            *ngIf="telephone.dirty && telephone.hasError('pattern')"
-            >Phone number only accept digits</span
-          >
-        </div>
-      </div>
-
-      <div class="form-group">
-        <div class="col-sm-offset-2 col-sm-10">
-          <button class="btn btn-default" (click)="gotoOwnerDetail(owner)">
-            Back
-          </button>
-          <button
-            type="submit"
-            [disabled]="!ownerForm.valid"
-            class="btn btn-default"
-          >
-            Update Owner
-          </button>
-        </div>
-      </div>
-    </form>
   </div>
-</div>
+  

--- a/src/app/pets/pet-add/pet-add.component.html
+++ b/src/app/pets/pet-add/pet-add.component.html
@@ -16,78 +16,82 @@
   ~  */
   -->
 
-<div class="container-fluid">
-  <div class="container xd-container">
-    <h2>
-      Add Pet
-    </h2>
-    <form class="form-horizontal" (ngSubmit)="onSubmit(petForm.value)" #petForm="ngForm">
-      <div class="form-group" hidden="true">
-        <input type="text" hidden="true" class="form-control" id="id" [(ngModel)]="pet.id" name="id"/>
-        <input type="text" hidden="true" class="form-control" id="owner" [(ngModel)]="pet.owner" name="owner"/>
-      </div>
-      <div class="form-group">
-        <label for="owner" class="col-sm-2 control-label">Owner</label>
-        <div class="col-sm-10">
-          <input id="owner_name" name="owner_name" class="form-control" type="text"
-                 value="{{ currentOwner.firstName }} {{ currentOwner.lastName }}" readonly/>
+  <div class="container-fluid">
+    <div class="container xd-container">
+      <h2>
+        Add Pet
+      </h2>
+      <form class="form-horizontal" (ngSubmit)="onSubmit(petForm.value)" #petForm="ngForm">
+        <div class="form-group" hidden="true">
+          <input type="text" hidden="true" class="form-control" id="id" [(ngModel)]="pet.id" name="id"/>
+          <input type="text" hidden="true" class="form-control" id="owner" [(ngModel)]="pet.owner" name="owner"/>
         </div>
-      </div>
-      <br/>
-
-      <div class="form-group has-feedback" [class.has-success]="name.dirty && name.valid"
-           [class.has-error]="name.dirty && !name.valid">
-        <label for="name" class="col-sm-2 control-label">Name</label>
-        <div class="col-sm-10">
-          <input id="name" name="name" required class="form-control" type="text" [(ngModel)]="pet.name"
-                 #name="ngModel"/>
-          <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="name.valid"
-                [class.glyphicon-remove]="!name.valid" aria-hidden="true"></span>
-          <span class="help-block" *ngIf="name.dirty && name.hasError('required')">Name is required</span>
-        </div>
-      </div>
-
-      <div class="form-group  has-feedback" [class.has-success]="birthDate.dirty && birthDate.valid"
-           [class.has-error]="birthDate.dirty && !birthDate.valid">
-        <label class="col-sm-2 control-label">Birth Date</label>
-        <div class="col-sm-10">
-          <input matInput [matDatepicker]="birthDateDatepicker" required [ngModel]="pet.birthDate | date:'yyyy-MM-dd'"
-                 name="birthDate" #birthDate="ngModel">
-          <mat-datepicker-toggle matSuffix [for]="birthDateDatepicker"></mat-datepicker-toggle>
-          <mat-datepicker #birthDateDatepicker></mat-datepicker>
-          <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="birthDate.valid"
-                [class.glyphicon-remove]="!birthDate.valid" aria-hidden="true"></span>
-          <span class="help-block"
-                *ngIf="birthDate.dirty && birthDate.hasError('required')">BirthDate is required</span>
-
-        </div>
-      </div>
-      <div class="control-group">
-        <div class="form-group has-feedback" [class.has-success]="type.dirty && type.valid"
-             [class.has-error]="type.dirty && !type.valid">
-          <label for="type" class="col-sm-2 control-label">Type </label>
+        <div class="form-group">
+          <label for="owner" class="col-sm-2 control-label">Owner</label>
           <div class="col-sm-10">
-            <select id="type" name="type" class="form-control" required [(ngModel)]="pet.type" #type="ngModel">
-              <option *ngFor="let type of petTypes"
-                      [ngValue]="type">{{ type.name }}
-              </option>
-            </select>
-            <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="type.valid"
-                  [class.glyphicon-remove]="!type.valid" aria-hidden="true"></span>
-
-            <span class="help-block"
-                  *ngIf="type.dirty && type.hasError('required')">pettype is required</span>
-
+            <input id="owner_name" name="owner_name" class="form-control" type="text"
+                   value="{{ currentOwner.firstName }} {{ currentOwner.lastName }}" readonly/>
           </div>
         </div>
-      </div>
-      <div class="form-group">
-        <div class="col-sm-offset-2 col-sm-10">
-          <br/>
-          <button class="btn btn-default" type="button" (click)="gotoOwnerDetail()">< Back</button>
-          <button class="btn btn-default" type="submit">Save Pet</button>
+        <br/>
+  
+        <div class="form-group has-feedback" [class.has-success]="name.dirty && name.valid"
+             [class.has-error]="name.dirty && !name.valid">
+          <label for="name" class="col-sm-2 control-label">Name</label>
+          <div class="col-sm-10">
+            <input id="name" name="name" minlength="1" maxlength="30"  pattern="^[A-Za-z0-9].{0,29}$" required class="form-control" type="text" [(ngModel)]="pet.name"
+                   #name="ngModel"/>
+            <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="name.valid"
+                  [class.glyphicon-remove]="!name.valid" aria-hidden="true"></span>
+            <span class="help-block" *ngIf="name.dirty && name.hasError('required')">Name is required</span>
+            <span class="help-block" *ngIf="name.dirty && name.hasError('minlength')">Name must be at least 1 character long</span>
+            <span class="help-block" *ngIf="name.dirty && name.hasError('maxlength')">Name may be at most 30 character long</span>
+            <span class="help-block" *ngIf="name.dirty && name.hasError('pattern')">Name must begin with a letter</span>
+          </div>
         </div>
-      </div>
-    </form>
+  
+        <div class="form-group  has-feedback" [class.has-success]="birthDate.dirty && birthDate.valid"
+             [class.has-error]="birthDate.dirty && !birthDate.valid">
+          <label class="col-sm-2 control-label">Birth Date</label>
+          <div class="col-sm-10">
+            <input matInput [matDatepicker]="birthDateDatepicker" required [ngModel]="pet.birthDate | date:'yyyy-MM-dd'"
+                   name="birthDate" #birthDate="ngModel">
+            <mat-datepicker-toggle matSuffix [for]="birthDateDatepicker"></mat-datepicker-toggle>
+            <mat-datepicker #birthDateDatepicker></mat-datepicker>
+            <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="birthDate.valid"
+                  [class.glyphicon-remove]="!birthDate.valid" aria-hidden="true"></span>
+            <span class="help-block"
+                  *ngIf="birthDate.dirty && birthDate.hasError('required')">BirthDate is required</span>
+  
+          </div>
+        </div>
+        <div class="control-group">
+          <div class="form-group has-feedback" [class.has-success]="type.dirty && type.valid"
+               [class.has-error]="type.dirty && !type.valid">
+            <label for="type" class="col-sm-2 control-label">Type </label>
+            <div class="col-sm-10">
+              <select id="type" name="type" class="form-control" required [(ngModel)]="pet.type" #type="ngModel">
+                <option *ngFor="let type of petTypes"
+                        [ngValue]="type">{{ type.name }}
+                </option>
+              </select>
+              <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="type.valid"
+                    [class.glyphicon-remove]="!type.valid" aria-hidden="true"></span>
+  
+              <span class="help-block"
+                    *ngIf="type.dirty && type.hasError('required')">pettype is required</span>
+  
+            </div>
+          </div>
+        </div>
+        <div class="form-group">
+          <div class="col-sm-offset-2 col-sm-10">
+            <br/>
+            <button class="btn btn-default" type="button" (click)="gotoOwnerDetail()">< Back</button>
+            <button class="btn btn-default" type="submit">Save Pet</button>
+          </div>
+        </div>
+      </form>
+    </div>
   </div>
-</div>
+  

--- a/src/app/pets/pet-add/pet-add.component.html
+++ b/src/app/pets/pet-add/pet-add.component.html
@@ -88,7 +88,7 @@
           <div class="col-sm-offset-2 col-sm-10">
             <br/>
             <button class="btn btn-default" type="button" (click)="gotoOwnerDetail()">< Back</button>
-            <button class="btn btn-default" type="submit">Save Pet</button>
+            <button class="btn btn-default" type="submit"  [disabled]="!petForm.valid">Save Pet</button>
           </div>
         </div>
       </form>

--- a/src/app/pets/pet-edit/pet-edit.component.html
+++ b/src/app/pets/pet-edit/pet-edit.component.html
@@ -38,11 +38,12 @@
       <div class="form-group has-feedback" [class.has-success]="name.dirty && name.valid" [class.has-error]="name.dirty &&  !name.valid">
         <label for="name" class="col-sm-2 control-label">Name</label>
         <div class="col-sm-10">
-          <input id="name" name="name" class="form-control" required type="text" [(ngModel)]="pet.name" #name="ngModel"/>
+          <input id="name" name="name" class="form-control"  minlength="1" maxlength="30"  pattern="^[A-Za-z0-9].{0,29}$" required type="text" [(ngModel)]="pet.name" #name="ngModel"/>
           <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="name.valid" [class.glyphicon-remove]="!name.valid" aria-hidden="true"></span>
           <span class="help-block" *ngIf="name.dirty && name.hasError('required')">Name is required</span>
-          <span class="help-block" *ngIf="name.dirty && name.hasError('minlength')">Name must be at least 2 characters long</span>
-
+          <span class="help-block" *ngIf="name.dirty && name.hasError('minlength')">Name must be at least 1 character long</span>
+          <span class="help-block" *ngIf="name.dirty && name.hasError('maxlength')">Name may be at most 30 character long</span>
+          <span class="help-block" *ngIf="name.dirty && name.hasError('pattern')">Name must begin with a letter</span>
         </div>
       </div>
       <div class="form-group has-feedback" [class.has-success]="birthDate.dirty && birthDate.valid" [class.has-error]="birthDate.dirty && !birthDate.valid">
@@ -82,7 +83,7 @@
         <div class="col-sm-offset-2 col-sm-10">
           <br/>
           <button class="btn btn-default" type="button" (click)="gotoOwnerDetail(pet.owner)">< Back</button>
-          <button class="btn btn-default" type="submit">Update Pet</button>
+          <button class="btn btn-default" type="submit" [disabled]="!petForm.valid" >Update Pet</button>
         </div>
       </div>
     </form>

--- a/src/app/pettypes/pettype-add/pettype-add.component.html
+++ b/src/app/pettypes/pettype-add/pettype-add.component.html
@@ -16,24 +16,28 @@
   ~  */
   -->
 
-<div class="container-fluid">
-  <div class="container xd-container">
-    <h2>New Pet Type</h2>
-    <form id="pettype" class="form-horizontal" (ngSubmit)="onSubmit(pettypeForm.value)" #pettypeForm="ngForm">
-      <div class="form-group" hidden="true">
-        <input type="text" hidden="true" class="form-control" id="id" [(ngModel)]="pettype.id" name="id"/>
-      </div>
-      <div class="form-group has-feedback"  [class.has-success]="name.dirty && name.valid" [class.has-error]="name.dirty &&  !name.valid">
-        <div class="form-group ">
-          <label class="col-sm-1 control-label">Name</label>
-          <div class="col-sm-6">
-            <input id="name" name="name" class="form-control" required type="text" [(ngModel)]="pettype.name" #name="ngModel"/>
-            <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="name.valid" [class.glyphicon-remove]="!name.valid" aria-hidden="true"></span>
-            <span class="help-block" *ngIf="(pettypeForm.submitted && name.hasError('required')) || (name.dirty && name.hasError('required'))">Name is required</span>
-          </div>
-          <button class="btn btn-default" type="submit">Save</button>
+  <div class="container-fluid">
+    <div class="container xd-container">
+      <h2>New Pet Type</h2>
+      <form id="pettype" class="form-horizontal" (ngSubmit)="onSubmit(pettypeForm.value)" #pettypeForm="ngForm">
+        <div class="form-group" hidden="true">
+          <input type="text" hidden="true" class="form-control" id="id" [(ngModel)]="pettype.id" name="id"/>
         </div>
-      </div>
-    </form>
+        <div class="form-group has-feedback"  [class.has-success]="name.dirty && name.valid" [class.has-error]="name.dirty &&  !name.valid">
+          <div class="form-group ">
+            <label class="col-sm-1 control-label">Name</label>
+            <div class="col-sm-6">
+              <input id="name" name="name" class="form-control" minlength="1" maxlength="80" pattern="^[A-Za-z0-9].{0,79}$" required type="text" [(ngModel)]="pettype.name" #name="ngModel"/>
+              <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="name.valid" [class.glyphicon-remove]="!name.valid" aria-hidden="true"></span>
+              <span class="help-block" *ngIf="name.dirty && name.hasError('maxlength')">Name may be only 80 characters long</span>
+              <span class="help-block" *ngIf="name.dirty && name.hasError('minlength')">Name may be at least 1 characters long</span>
+              <span class="help-block" *ngIf="name.dirty && name.hasError('pattern')">Name must begin with a letter or digit</span>
+               <span class="help-block" *ngIf="(pettypeForm.submitted && name.hasError('required')) || (name.dirty && name.hasError('required'))">Name is required</span>
+            </div>
+            <button class="btn btn-default" type="submit" [disabled]="!pettypeForm.valid">Save</button>
+          </div>
+        </div>
+      </form>
+    </div>
   </div>
-</div>
+  

--- a/src/app/pettypes/pettype-edit/pettype-edit.component.html
+++ b/src/app/pettypes/pettype-edit/pettype-edit.component.html
@@ -16,25 +16,29 @@
   ~  */
   -->
 
-<div class="container-fluid">
-  <div class="container xd-container">
-    <h2>Edit Pet Type</h2>
-    <form id="pettype" class="form-horizontal" (ngSubmit)="onSubmit(pettypeForm.value)" #pettypeForm="ngForm">
-      <div class="form-group" hidden="true">
-        <input type="text" hidden="true" class="form-control" id="id" [(ngModel)]="pettype.id" name="id"/>
-      </div>
-      <div class="form-group has-feedback"  [class.has-success]="name.dirty && name.valid" [class.has-error]="name.dirty &&  !name.valid">
-        <div class="form-group ">
-          <label class="col-sm-1 control-label">Name</label>
-          <div class="col-sm-6">
-            <input id="name" name="name" class="form-control" required type="text" [(ngModel)]="pettype.name" #name="ngModel"/>
-            <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="name.valid" [class.glyphicon-remove]="!name.valid" aria-hidden="true"></span>
-            <span class="help-block" *ngIf="name.dirty && name.hasError('required')">Name is required</span>
-          </div>
-          <button class="btn btn-default" type="submit">Update</button>
-          <button class="btn btn-default" (click)="onBack()">Cancel</button>
+  <div class="container-fluid">
+    <div class="container xd-container">
+      <h2>Edit Pet Type</h2>
+      <form id="pettype" class="form-horizontal" (ngSubmit)="onSubmit(pettypeForm.value)" #pettypeForm="ngForm">
+        <div class="form-group" hidden="true">
+          <input type="text" hidden="true" class="form-control" id="id" [(ngModel)]="pettype.id" name="id"/>
         </div>
-      </div>
-    </form>
+        <div class="form-group has-feedback"  [class.has-success]="name.dirty && name.valid" [class.has-error]="name.dirty &&  !name.valid">
+          <div class="form-group ">
+            <label class="col-sm-1 control-label">Name</label>
+            <div class="col-sm-6">
+              <input id="name" name="name" class="form-control" minlength="1" maxlength="80" pattern="^[A-Za-z0-9].{0,79}$" required type="text" [(ngModel)]="pettype.name" #name="ngModel"/>
+              <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="name.valid" [class.glyphicon-remove]="!name.valid" aria-hidden="true"></span>
+              <span class="help-block" *ngIf="name.dirty && name.hasError('maxlength')">Name may be only 80 characters long</span>
+              <span class="help-block" *ngIf="name.dirty && name.hasError('minlength')">Name may be at least 1 characters long</span>
+              <span class="help-block" *ngIf="name.dirty && name.hasError('pattern')">Name must begin with a letter or digit</span>
+              <span class="help-block" *ngIf="name.dirty && name.hasError('required')">Name is required</span>
+            </div>
+            <button class="btn btn-default" type="submit" [disabled]="!pettypeForm.valid">Update</button>
+            <button class="btn btn-default" (click)="onBack()">Cancel</button>
+          </div>
+        </div>
+      </form>
+    </div>
   </div>
-</div>
+  

--- a/src/app/specialties/specialty-add/specialty-add.component.html
+++ b/src/app/specialties/specialty-add/specialty-add.component.html
@@ -5,22 +5,19 @@
       <div class="form-group" hidden="true">
         <input type="text" hidden="true" class="form-control" id="id" [(ngModel)]="speciality.id" name="id" />
       </div>
-      <div *ngIf="
-          specialityName.invalid &&
-          (specialityName.dirty || specialityName.touched)
-        " class="alert alert-danger">
-        Loading...
-        <div *ngIf="specialityName.errors?.required">Name is required.</div>
-      </div>
 
-      <div class="form-group has-feedback">
+      <div class="form-group has-feedback"   [class.has-success]="specialityName.dirty && specialityName.valid" [class.has-error]="specialityName.dirty &&  !specialityName.valid">
         <div class="form-group">
           <label class="col-sm-1 control-label">Name</label>
           <div class="col-sm-6">
-            <input id="name" name="name" class="form-control" type="text" [(ngModel)]="speciality.name" #specialityName="ngModel" />
+            <input id="name" name="name" class="form-control"  minlength="1" maxlength="80" pattern="^[A-Za-z0-9].{0,79}$" required type="text" [(ngModel)]="speciality.name" #specialityName="ngModel" />
+            <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="specialityName.valid" [class.glyphicon-remove]="!specialityName.valid" aria-hidden="true"></span>
+            <span class="help-block" *ngIf="specialityName.dirty && specialityName.hasError('maxlength')">Name may be only 80 characters long</span>
+            <span class="help-block" *ngIf="specialityName.dirty && specialityName.hasError('minlength')">Name must be at least 1 characters long</span>
+            <span class="help-block" *ngIf="specialityName.dirty && specialityName.hasError('pattern')">Name must begin with a letter or digit</span>
             <span class="help-block" *ngIf="specialityForm.submitted || specialityName.dirty && specialityName.hasError('required')">Name is required</span>
           </div>
-          <button class="btn btn-default" type="submit">Save</button>
+          <button class="btn btn-default" type="submit" [disabled]="!specialityForm.valid">Save</button>
         </div>
       </div>
     </form>

--- a/src/app/specialties/specialty-edit/specialty-edit.component.html
+++ b/src/app/specialties/specialty-edit/specialty-edit.component.html
@@ -27,7 +27,7 @@
           <div class="form-group has-feedback" [class.has-success]="name.dirty && name.valid" [class.has-error]="name.dirty && !name.valid">
             <label class="col-sm-1 control-label">Name</label>
             <div class="col-sm-6">
-              <input id="name" name="name" class="form-control" type="text"  minlength="1" maxlength="30" pattern="^[A-Za-z0-9].{0,29}$" required [(ngModel)]="specialty.name" #name="ngModel"/>
+              <input id="name" name="name" class="form-control" type="text"  minlength="1" maxlength="80" pattern="^[A-Za-z0-9].{0,79}$" required [(ngModel)]="specialty.name" #name="ngModel"/>
               <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="name.valid" [class.glyphicon-remove]="!name.valid" aria-hidden="true"></span>
               <span class="help-block" *ngIf="name.dirty && name.hasError('maxlength')">Name may be only 80 characters long</span>
               <span class="help-block" *ngIf="name.dirty && name.hasError('minlength')">Name must be at least 1 characters long</span>

--- a/src/app/specialties/specialty-edit/specialty-edit.component.html
+++ b/src/app/specialties/specialty-edit/specialty-edit.component.html
@@ -32,6 +32,7 @@
               <span class="help-block" *ngIf="name.dirty && name.hasError('maxlength')">Name may be only 80 characters long</span>
               <span class="help-block" *ngIf="name.dirty && name.hasError('minlength')">Name must be at least 1 characters long</span>
               <span class="help-block" *ngIf="name.dirty && name.hasError('pattern')">Name must begin with a letter or digit</span>
+              <span class="help-block" *ngIf="name.dirty && name.hasError('required')">Name is required</span>
              </div>
             <button class="btn btn-default" type="submit" [disabled]="!specialtyForm.valid">Update</button>
             <button class="btn btn-default" (click)="onBack()">Cancel</button>

--- a/src/app/specialties/specialty-edit/specialty-edit.component.html
+++ b/src/app/specialties/specialty-edit/specialty-edit.component.html
@@ -16,25 +16,28 @@
   ~  */
   -->
 
-<div class="container-fluid">
-  <div class="container xd-container">
-    <h2>Edit Specialty</h2>
-    <form id="specialty" class="form-horizontal" (ngSubmit)="onSubmit(specialtyForm.value)" #specialtyForm="ngForm">
-      <div class="form-group" hidden="true">
-        <input type="text" hidden="true" class="form-control" id="id" [(ngModel)]="specialty.id" name="id"/>
-      </div>
-      <div class="form-group has-feedback">
-        <div class="form-group has-feedback" [class.has-success]="name.dirty && name.valid" [class.has-error]="name.dirty && !name.valid">
-          <label class="col-sm-1 control-label">Name</label>
-          <div class="col-sm-6">
-            <input id="name" name="name" class="form-control" type="text" required [(ngModel)]="specialty.name" #name="ngModel"/>
-            <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="name.valid" [class.glyphicon-remove]="!name.valid" aria-hidden="true"></span>
-            <span class="help-block" *ngIf="name.dirty && name.hasError('required')">Name is required</span>
-          </div>
-          <button class="btn btn-default" type="submit">Update</button>
-          <button class="btn btn-default" (click)="onBack()">Cancel</button>
+  <div class="container-fluid">
+    <div class="container xd-container">
+      <h2>Edit Specialty</h2>
+      <form id="specialty" class="form-horizontal" (ngSubmit)="onSubmit(specialtyForm.value)" #specialtyForm="ngForm">
+        <div class="form-group" hidden="true">
+          <input type="text" hidden="true" class="form-control" id="id" [(ngModel)]="specialty.id" name="id"/>
         </div>
-      </div>
-    </form>
+        <div class="form-group has-feedback">
+          <div class="form-group has-feedback" [class.has-success]="name.dirty && name.valid" [class.has-error]="name.dirty && !name.valid">
+            <label class="col-sm-1 control-label">Name</label>
+            <div class="col-sm-6">
+              <input id="name" name="name" class="form-control" type="text"  minlength="1" maxlength="30" pattern="^[A-Za-z0-9].{0,29}$" required [(ngModel)]="specialty.name" #name="ngModel"/>
+              <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="name.valid" [class.glyphicon-remove]="!name.valid" aria-hidden="true"></span>
+              <span class="help-block" *ngIf="name.dirty && name.hasError('maxlength')">Name may be only 80 characters long</span>
+              <span class="help-block" *ngIf="name.dirty && name.hasError('minlength')">Name must be at least 1 characters long</span>
+              <span class="help-block" *ngIf="name.dirty && name.hasError('pattern')">Name must begin with a letter or digit</span>
+             </div>
+            <button class="btn btn-default" type="submit" [disabled]="!specialtyForm.valid">Update</button>
+            <button class="btn btn-default" (click)="onBack()">Cancel</button>
+          </div>
+        </div>
+      </form>
+    </div>
   </div>
-</div>
+  

--- a/src/app/vets/vet-add/vet-add.component.html
+++ b/src/app/vets/vet-add/vet-add.component.html
@@ -16,50 +16,55 @@
   ~  */
   -->
 
-<div class="container-fluid">
-  <div class="container xd-container">
-    <h2>New Veterinarian</h2>
-    <form id="vet" class="form-horizontal" (ngSubmit)="onSubmit(vetForm.value)" #vetForm="ngForm">
-      <div class="form-group" hidden="true">
-        <input type="text" hidden="true" class="form-control" id="id" [(ngModel)]="vet.id" name="id"/>
-      </div>
-      <div class="form-group has-feedback" [class.has-success]="firstName.dirty && firstName.valid" [class.has-error]="firstName.dirty &&  !firstName.valid">
-        <label for="firstName" class="col-sm-2 control-label">First Name</label>
-        <div class="col-sm-10">
-          <input type="text" class="form-control" id="firstName" [(ngModel)]="vet.firstName" minlength="2" required name="firstName" #firstName="ngModel"/>
-          <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="firstName.valid" [class.glyphicon-remove]="!firstName.valid" aria-hidden="true"></span>
-          <span class="help-block" *ngIf="(vetForm.submitted && firstName.hasError('required')) || (firstName.dirty && firstName.hasError('required'))">First name is required</span>
-          <span class="help-block" *ngIf="firstName.dirty && firstName.hasError('minlength')">First name must be at least 2 characters long</span>
+  <div class="container-fluid">
+    <div class="container xd-container">
+      <h2>New Veterinarian</h2>
+      <form id="vet" class="form-horizontal" (ngSubmit)="onSubmit(vetForm.value)" #vetForm="ngForm">
+        <div class="form-group" hidden="true">
+          <input type="text" hidden="true" class="form-control" id="id" [(ngModel)]="vet.id" name="id"/>
         </div>
-      </div>
-      <div class="form-group has-feedback" [class.has-success]="lastName.dirty && lastName.valid" [class.has-error]="lastName.dirty && !lastName.valid">
-        <label for="lastName" class="col-sm-2 control-label">Last Name</label>
-        <div class="col-sm-10">
-          <input type="text" class="form-control" id="lastName" [(ngModel)]="vet.lastName" name="lastName" minlength="2" required #lastName="ngModel"/>
-          <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="lastName.valid" [class.glyphicon-remove]="!lastName.valid" aria-hidden="true"></span>
-          <span class="help-block" *ngIf="(vetForm.submitted && lastName.hasError('required')) || (lastName.dirty && lastName.hasError('required'))">Last name is required</span>
-          <span class="help-block" *ngIf="lastName.dirty && lastName.hasError('minlength')">Last name must be at least 2 characters long</span>
-        </div>
-      </div>
-      <div class="control-group">
-        <div class="form-group ">
-          <label for="specialties" class="col-sm-2 control-label">Type </label>
+        <div class="form-group has-feedback" [class.has-success]="firstName.dirty && firstName.valid" [class.has-error]="firstName.dirty &&  !firstName.valid">
+          <label for="firstName" class="col-sm-2 control-label">First Name</label>
           <div class="col-sm-10">
-            <select id="specialties" name="specialties" class="form-control" [(ngModel)]="selectedSpecialty">
-              <option *ngFor="let spec of specialtiesList" [ngValue]="spec">
-                {{ spec.name }}
-              </option>
-            </select>
+            <input type="text" class="form-control" id="firstName" [(ngModel)]="vet.firstName"  minlength="1" maxlength="30" pattern="^[a-zA-Z]*$"  required name="firstName" #firstName="ngModel"/>
+            <span class="help-block" *ngIf="firstName.dirty && firstName.hasError('maxlength')">First Name may be only 30 characters long</span>
+            <span class="help-block" *ngIf="firstName.dirty && firstName.hasError('minlength')">First Name must be at least 1 characters long</span>
+             <span class="help-block" *ngIf="firstName.dirty && firstName.hasError('pattern')">First Name may only consist of letters</span>
+            <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="firstName.valid" [class.glyphicon-remove]="!firstName.valid" aria-hidden="true"></span>
+            <span class="help-block" *ngIf="(vetForm.submitted && firstName.hasError('required')) || (firstName.dirty && firstName.hasError('required'))">First name is required</span>
           </div>
         </div>
-      </div>
-      <div class="form-group">
-        <div class="col-sm-offset-2 col-sm-10">
-          <br/>
-          <button class="btn btn-default" type="button" (click)="gotoVetList()">< Back</button>
-          <button class="btn btn-default" type="submit">Save Vet</button>
+        <div class="form-group has-feedback" [class.has-success]="lastName.dirty && lastName.valid" [class.has-error]="lastName.dirty && !lastName.valid">
+          <label for="lastName" class="col-sm-2 control-label">Last Name</label>
+          <div class="col-sm-10">
+            <input type="text" class="form-control" id="lastName" [(ngModel)]="vet.lastName" name="lastName" minlength="1" maxlength="30" pattern="^[a-zA-Z]*$"  required #lastName="ngModel"/>
+            <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="lastName.valid" [class.glyphicon-remove]="!lastName.valid" aria-hidden="true"></span>
+            <span class="help-block" *ngIf="lastName.dirty && lastName.hasError('maxlength')">Last Name may be only 30 characters long</span>
+            <span class="help-block" *ngIf="lastName.dirty && lastName.hasError('minlength')">Last Name must be at least 1 characters long</span>
+             <span class="help-block" *ngIf="lastName.dirty && lastName.hasError('pattern')">Last Name may only consist of letters </span>
+            <span class="help-block" *ngIf="(vetForm.submitted && lastName.hasError('required')) || (lastName.dirty && lastName.hasError('required'))">Last name is required</span>
+          </div>
         </div>
-      </div>
-    </form>
+        <div class="control-group">
+          <div class="form-group ">
+            <label for="specialties" class="col-sm-2 control-label">Type </label>
+            <div class="col-sm-10">
+              <select id="specialties" name="specialties" class="form-control" [(ngModel)]="selectedSpecialty">
+                <option *ngFor="let spec of specialtiesList" [ngValue]="spec">
+                  {{ spec.name }}
+                </option>
+              </select>
+            </div>
+          </div>
+        </div>
+        <div class="form-group">
+          <div class="col-sm-offset-2 col-sm-10">
+            <br/>
+            <button class="btn btn-default" type="button" (click)="gotoVetList()">< Back</button>
+            <button class="btn btn-default" type="submit"  [disabled]="!vetForm.valid">Save Vet</button>
+          </div>
+        </div>
+      </form>
+    </div>
   </div>
-</div>
+  

--- a/src/app/vets/vet-edit/vet-edit.component.html
+++ b/src/app/vets/vet-edit/vet-edit.component.html
@@ -16,50 +16,55 @@
   ~  */
   -->
 
-<div class="container-fluid">
-  <div class="container xd-container">
-    <h2>Edit Veterinarian</h2>
-    <form id="vet_form" class="form-horizontal" (ngSubmit)="onSubmit(vetEditForm.value)" [formGroup]="vetEditForm">
-      <div class="form-group" hidden="true">
-        <input type="text" hidden="true" class="form-control" id="id" name="id" formControlName="id"/>
-      </div>
-      <div class="form-group has-feedback" [class.has-success]="firstNameCtrl.dirty && firstNameCtrl.valid" [class.has-error]="firstNameCtrl.dirty &&  !firstNameCtrl.valid">
-        <label for="firstName" class="col-sm-2 control-label">First Name</label>
-        <div class="col-sm-10">
-          <input type="text" class="form-control" id="firstName" name="firstName" formControlName="firstName"/>
-          <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="firstNameCtrl.valid" [class.glyphicon-remove]="!firstNameCtrl.valid" aria-hidden="true"></span>
-          <span class="help-block" *ngIf="firstNameCtrl.dirty && firstNameCtrl.hasError('required')">First name is required</span>
-          <span class="help-block" *ngIf="firstNameCtrl.dirty && firstNameCtrl.hasError('minlength')">First name must be at least 2 characters long</span>
+  <div class="container-fluid">
+    <div class="container xd-container">
+      <h2>Edit Veterinarian</h2>
+      <form id="vet_form" class="form-horizontal" (ngSubmit)="onSubmit(vetEditForm.value)" [formGroup]="vetEditForm">
+        <div class="form-group" hidden="true">
+          <input type="text" hidden="true" class="form-control" id="id" name="id" formControlName="id"/>
         </div>
-      </div>
-      <div class="form-group has-feedback" [class.has-success]="lastNameCtrl.dirty && lastNameCtrl.valid" [class.has-error]="lastNameCtrl.dirty && !lastNameCtrl.valid">
-        <label for="lastName" class="col-sm-2 control-label">Last Name</label>
-        <div class="col-sm-10">
-          <input type="text" class="form-control" id="lastName" name="lastName" formControlName="lastName"/>
-          <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="lastNameCtrl.valid" [class.glyphicon-remove]="!lastNameCtrl.valid" aria-hidden="true"></span>
-          <span class="help-block" *ngIf="lastNameCtrl.dirty && lastNameCtrl.hasError('required')">Last name is required</span>
-          <span class="help-block" *ngIf="lastNameCtrl.dirty && lastNameCtrl.hasError('minlength')">Last name must be at least 2 characters long</span>
+        <div class="form-group has-feedback" [class.has-success]="firstNameCtrl.dirty && firstNameCtrl.valid" [class.has-error]="firstNameCtrl.dirty &&  !firstNameCtrl.valid">
+          <label for="firstName" class="col-sm-2 control-label">First Name</label>
+          <div class="col-sm-10">
+            <input type="text" class="form-control" id="firstName" name="firstName" minlength="1" maxlength="30" pattern="^[A-Za-z]*$"  required formControlName="firstName"/>
+            <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="firstNameCtrl.valid" [class.glyphicon-remove]="!firstNameCtrl.valid" aria-hidden="true"></span>
+            <span class="help-block" *ngIf="firstNameCtrl.dirty && firstNameCtrl.hasError('maxlength')">First Name may be only 30 characters long</span>
+            <span class="help-block" *ngIf="firstNameCtrl.dirty && firstNameCtrl.hasError('minlength')">First Name must be at least 1 characters long</span>
+             <span class="help-block" *ngIf="firstNameCtrl.dirty && firstNameCtrl.hasError('pattern')">First Name may only consist of letters</span>
+            <span class="help-block" *ngIf="firstNameCtrl.dirty && firstNameCtrl.hasError('required')">First name is required</span>
+          </div>
         </div>
-      </div>
-      <div class="control-group">
-        <div class="form-group ">
-          <label for="spec" class="col-sm-2 control-label">Specialties</label>
-            <mat-form-field class="col-sm-10">
-              <mat-select  [compareWith]="compareSpecFn" id="spec" name="specialties" formControlName="specialties" multiple>
-                <mat-option *ngFor="let specialty of specList" [value]="specialty">
-                  {{ specialty.name }}
-                </mat-option>
-              </mat-select>
-            </mat-form-field>
+        <div class="form-group has-feedback" [class.has-success]="lastNameCtrl.dirty && lastNameCtrl.valid" [class.has-error]="lastNameCtrl.dirty && !lastNameCtrl.valid">
+          <label for="lastName" class="col-sm-2 control-label">Last Name</label>
+          <div class="col-sm-10">
+            <input type="text" class="form-control" id="lastName" name="lastName" formControlName="lastName" minlength="1" maxlength="30" pattern="^[A-Za-z]*$"  required/>
+            <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="lastNameCtrl.valid" [class.glyphicon-remove]="!lastNameCtrl.valid" aria-hidden="true"></span>
+            <span class="help-block" *ngIf="lastNameCtrl.dirty && lastNameCtrl.hasError('maxlength')">Last Name may be only 30 characters long</span>
+            <span class="help-block" *ngIf="lastNameCtrl.dirty && lastNameCtrl.hasError('minlength')">Last Name must be at least 1 characters long</span>
+            <span class="help-block" *ngIf="lastNameCtrl.dirty && lastNameCtrl.hasError('pattern')">Last Name may only consist of letters</span>
+            <span class="help-block" *ngIf="lastNameCtrl.dirty && lastNameCtrl.hasError('required')">Last name is required</span>
+          </div>
         </div>
-      </div>
-      <div class="form-group">
-        <div class="col-sm-offset-2 col-sm-10">
-          <br/>
-          <button class="btn btn-default" type="button" (click)="gotoVetList()">< Back</button>
-          <button class="btn btn-default" type="submit" [disabled]="vetEditForm.invalid">Save Vet</button>
+        <div class="control-group">
+          <div class="form-group ">
+            <label for="spec" class="col-sm-2 control-label">Specialties</label>
+              <mat-form-field class="col-sm-10">
+                <mat-select  [compareWith]="compareSpecFn" id="spec" name="specialties" formControlName="specialties" multiple>
+                  <mat-option *ngFor="let specialty of specList" [value]="specialty">
+                    {{ specialty.name }}
+                  </mat-option>
+                </mat-select>
+              </mat-form-field>
+          </div>
         </div>
-      </div>
-    </form>
+        <div class="form-group">
+          <div class="col-sm-offset-2 col-sm-10">
+            <br/>
+            <button class="btn btn-default" type="button" (click)="gotoVetList()">< Back</button>
+            <button class="btn btn-default" type="submit" [disabled]="vetEditForm.invalid">Save Vet</button>
+          </div>
+        </div>
+      </form>
+    </div>
   </div>
-</div>
+  

--- a/src/app/vets/vet-edit/vet-edit.component.html
+++ b/src/app/vets/vet-edit/vet-edit.component.html
@@ -31,18 +31,18 @@
             <span class="help-block" *ngIf="firstNameCtrl.dirty && firstNameCtrl.hasError('maxlength')">First Name may be only 30 characters long</span>
             <span class="help-block" *ngIf="firstNameCtrl.dirty && firstNameCtrl.hasError('minlength')">First Name must be at least 1 characters long</span>
              <span class="help-block" *ngIf="firstNameCtrl.dirty && firstNameCtrl.hasError('pattern')">First Name may only consist of letters</span>
-            <span class="help-block" *ngIf="firstNameCtrl.dirty && firstNameCtrl.hasError('required')">First name is required</span>
+            <span class="help-block" *ngIf="firstNameCtrl.dirty && firstNameCtrl.hasError('required')">First Name is required</span>
           </div>
         </div>
         <div class="form-group has-feedback" [class.has-success]="lastNameCtrl.dirty && lastNameCtrl.valid" [class.has-error]="lastNameCtrl.dirty && !lastNameCtrl.valid">
           <label for="lastName" class="col-sm-2 control-label">Last Name</label>
           <div class="col-sm-10">
-            <input type="text" class="form-control" id="lastName" name="lastName" formControlName="lastName" minlength="1" maxlength="30" pattern="^[A-Za-z]*$"  required/>
+            <input type="text" class="form-control" id="lastName" name="lastName" minlength="1" maxlength="30" pattern="^[A-Za-z]*$"  required formControlName="lastName"/>
             <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="lastNameCtrl.valid" [class.glyphicon-remove]="!lastNameCtrl.valid" aria-hidden="true"></span>
             <span class="help-block" *ngIf="lastNameCtrl.dirty && lastNameCtrl.hasError('maxlength')">Last Name may be only 30 characters long</span>
             <span class="help-block" *ngIf="lastNameCtrl.dirty && lastNameCtrl.hasError('minlength')">Last Name must be at least 1 characters long</span>
             <span class="help-block" *ngIf="lastNameCtrl.dirty && lastNameCtrl.hasError('pattern')">Last Name may only consist of letters</span>
-            <span class="help-block" *ngIf="lastNameCtrl.dirty && lastNameCtrl.hasError('required')">Last name is required</span>
+            <span class="help-block" *ngIf="lastNameCtrl.dirty && lastNameCtrl.hasError('required')">Last Name is required</span>
           </div>
         </div>
         <div class="control-group">

--- a/src/app/visits/visit-add/visit-add.component.html
+++ b/src/app/visits/visit-add/visit-add.component.html
@@ -58,11 +58,13 @@
         <div class="form-group has-feedback " [class.has-success]="description.dirty && description.valid" [class.has-error]="description.dirty && !description.valid">
           <label class="col-sm-2 control-label">Description</label>
           <div class="col-sm-10">
-            <input id="description" name="description" class="form-control"  required type="text"
+            <input id="description" name="description" class="form-control"   minlength="1" maxlength="255" required type="text"
                    [(ngModel)]="visit.description" #description="ngModel"/>
             <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="description.valid" [class.glyphicon-remove]="!description.valid" aria-hidden="true"></span>
             <span class="help-block" *ngIf="description.dirty && description.hasError('required')">Description is required</span>
-            <span class="help-block" *ngIf="description.dirty && description.hasError('minlength')">Description must be at least 2 characters long</span>
+            <span class="help-block" *ngIf="description.dirty && description.hasError('minlength')">Description must be at least 1 characters long</span>
+            <span class="help-block" *ngIf="description.dirty && description.hasError('maxlength')">Description may be at most 255 characters long</span>
+
 
           </div>
         </div>

--- a/src/app/visits/visit-add/visit-add.component.html
+++ b/src/app/visits/visit-add/visit-add.component.html
@@ -75,7 +75,7 @@
           <input type="hidden" name="id" id="id" [(ngModel)]="visit.id"/>
           <input type="hidden" name="pet" id="pet" [(ngModel)]="visit.pet"/>
           <button class="btn btn-default" type="button" (click)="gotoOwnerDetail()">Back</button>
-          <button class="btn btn-default" type="submit">Add Visit</button>
+          <button class="btn btn-default" type="submit" [disabled]="!visitForm.valid">Add Visit</button>
         </div>
       </div>
     </form>

--- a/src/app/visits/visit-edit/visit-edit.component.html
+++ b/src/app/visits/visit-edit/visit-edit.component.html
@@ -57,12 +57,13 @@
         <div class="form-group has-feedback " [class.has-success]="description.dirty && description.valid" [class.has-error]="description.dirty && !description.valid">
           <label class="col-sm-2 control-label">Description</label>
           <div class="col-sm-10">
-            <input id="description" name="description" class="form-control" type="text" required
+            <input id="description" name="description" class="form-control" type="text" minlength="1" maxlength="255" required
                    [(ngModel)]="visit.description" #description="ngModel"/>
             <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="description.valid" [class.glyphicon-remove]="!description.valid" aria-hidden="true"></span>
             <span class="help-block" *ngIf="description.dirty && description.hasError('required')">Description is required</span>
-
-          </div>
+             <span class="help-block" *ngIf="description.dirty && description.hasError('minlength')">Description must be at least 1 characters long</span>           <span class="help-block" *ngIf="description.dirty && description.hasError('maxlength')">Description may be at most 255 charaters long</span>
+             <span class="help-block" *ngIf="description.dirty && description.hasError('maxlength')">Description may be at most 255 characters long</span>           <span class="help-block" *ngIf="description.dirty && description.hasError('maxlength')">Description may be at most 255 charaters long</span>
+         </div>
         </div>
 
       </div>
@@ -71,7 +72,7 @@
           <input type="hidden" name="id" id="id" [(ngModel)]="visit.id"/>
           <input type="hidden" name="pet" id="pet" [(ngModel)]="visit.pet"/>
           <button class="btn btn-default" type="button" (click)="gotoOwnerDetail()">Back</button>
-          <button class="btn btn-default" type="submit">Update Visit</button>
+          <button class="btn btn-default" type="submit" [disabled]="visitForm.invalid">Update Visit</button>
         </div>
       </div>
     </form>


### PR DESCRIPTION
# Align validation rules of add and edit forms to Rest OpenAPI validation rules

The pet clinic rest api defines validation rules for component properties ([see here](https://github.com/spring-petclinic/spring-petclinic-rest/blob/master/src/main/resources/openapi.yml)). 

The pet clinic angular application defines validation rules for fields (bound to the previously cited component properties) within the angular components \<entityname>-add.component.html and \<entityname>-edit.component.html files.

Currently, there is a lack of alignment among these. Some definitions in the angular application are different, and some are not defined at all.

## Overview

The following tables document the situation before this change

**Field** is the name of the openAPI component property
**Rule** is the kind of rule enforced
**openAPI** is the validation rule value openAPI enforces
**Angular Add** is the validation rule the Angluar front end enforces in add functionality
**Angular Edit** is the validation rule then Angular front end enforces in the edit functionality


### Specialty 


| Field |  Rule | openAPI | Angular Add | Angular Edit |
|:---|:---|:---|:---|:---|
| name | minLength | 1 |  |
| name  | maxLength | 80 | |
| name | required | + | | + |

### Owner
| Field |  Rule | openAPI | Angular Add | Angular Edit |
|:---|:---|:---|:---|:---|
| firstName | minLength | 1 | 2 | 2 |
| firstName  | maxLength | 30 | |
| firstName | pattern | \^[a-zA-Z]*$| |
| firstName | required | + | +| +|
| lastName | minLength | 1 | 2 | 2|
| lastName  | maxLength | 30 | |
| lastName | pattern | \^[a-zA-Z]*$| |
| lastName | required | + | + | + | +|
| address | minLength | 1 |  |
| address  | maxLength | 255 | |
| address | required | + | + |
| city | minLength | 1 |  | 
| city   | maxLength | 80 | |
| city | required | + | + | +|
| telephone | minLength | 1 |  |
| telephone  | maxLength | 20 | 10 | 10 |
| telephone | pattern | \^[0-9]*$|\^[0-9]{0,10}$ |\^[0-9]{0,10}$ |
| telephone | required | + | +  | + |

### Pet

| Field |  Rule | openAPI | Angular Add | Angular Edit |
|:---|:---|:---|:---|:---|
| name  | maxLength | 30 | |
| name | required | + | |  | +
| birthDate | required | + |  + | +|


### Vet


| Field |  Rule | openAPI | Angular Add | Angular Edit |
|:---|:---|:---|:---|:---|
| firstName | minLength | 1 |  2|
| firstName  | maxLength | 30 | |
| firstName | pattern | \^[a-zA-Z]*$| |
| firstName | required | + | +|
| lastName | minLength | 1 |  2|
| lastName  | maxLength | 30 | |
| lastName | required | + | +|
| lastName | pattern | \^[a-zA-Z]*$| |
| specialties  | - | - | |
| specialties | required | + | |

### Visit

| Field |  Rule | openAPI | Angular Add | Angular Edit |
|:---|:---|:---|:---|:---|
 date  | - | - | |
| description | minLength | 1 |  |
| description  | maxLength | 255 | |
| description | required | + | +|+


### PetType 

| Field |  Rule | openAPI | Angular Add | Angular Edit |
|:---|:---|:---|:---|:---|
| name | minLength | 1 |  |
| name  | maxLength | 80 | |
| name | required | + | |


### User

User is currently not implemented in the angular front end.

| Field |  Rule | openAPI | Angular Add | Angular Edit |
|:---|:---|:---|:---|:---|
| username | minLength | 1 | NA  | NA |
| username  | maxLength | 80 | NA| NA |
| username | required | + | NA | NA |
| password | minLength | 1 | NA | NA |
| pasword  | maxLength | 80 | NA | NA |

NA - not applicable

### Role

Role is currently not implemented in the angular front end.

| Field |  Rule | openAPI | Angular Add | Angular Edit |
|:---|:---|:---|:---|:---|
| name | minLength | 1  |  NA | NA |
| name | maxLength | 80 | NA  | NA |
| name | required  | +  | NA  | NA |

NA - not applicable

## Note

An anomaly is defined within the openAPI validation.

We define some fields with a minimal length but we do not have a pattern validation rule defined. This enables the user of the api to define i.e. names with all blank characters. Here in the future, the openApi description should define pattern validation rules.

In the meantime, it is assumed, that any required name field with a length > 0 may not start with a character other than [A-za-z]. This is implemented in this pull request.

# What did change?

The input field requirement rules are adjusted in the add-component.html or edit.component.html files so that they follow the openAPI rules with one exception.

Where names are defined the leading character must be a letter or digit so that all spaces names are not allowed. The rule used here is **pattern="\^[A-Za-z0-9].{0,N}$** with N the maxlength - 1;

**Example** 

From 
```
 <input type="text" class="form-control" id="firstName" [(ngModel)]="vet.firstName" minlength="2" required name="firstName" #firstName="ngModel"/>
```
 to 
```
 <input type="text" class="form-control" id="firstName" [(ngModel)]="vet.firstName"  minlength="1" maxlength="30" pattern="^[A-Za-z].{0,29}$"  required name="firstName" #firstName="ngModel"/>
 ```


Then the help block for the fields are adjusted

**Example**
From
```
     <span class="help-block" *ngIf="(vetForm.submitted && firstName.hasError('required')) || (firstName.dirty && firstName.hasError('required'))">First name is required</span>
          <span class="help-block" *ngIf="firstName.dirty && firstName.hasError('minlength')">First name must be at least 2 characters long</span>
   ```
  
  To

  ````
         <span class="help-block" *ngIf="firstName.dirty && firstName.hasError('maxlength')">First Name may be only 30 characters long</span>
            <span class="help-block" *ngIf="firstName.dirty && firstName.hasError('minlength')">First Name must be at least 1 characters long</span>
             <span class="help-block" *ngIf="firstName.dirty && firstName.hasError('pattern')">First Name may not start with a space character</span>
  ````


And finally, the validation state enables the add/save button.

**Example**

From

````
  <button class="btn btn-default" type="submit">Save Vet</button>
````

To

````
 <button class="btn btn-default" type="submit"  [disabled]="!vetForm.valid">Save Vet</button>
 `````


### Extra

The specialty add function displayed error messages in the wrong color (grey insted of red).The reason was a missing definition.

````[class.has-success]="specialityName.dirty && specialityName.valid" [class.has-error]="specialityName.dirty &&  !specialityName.valid"````

This was corrected in the file specialty-add.component.html too.