### PR TITLE
Fix: restricted pet birth date to past or present in UI

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -151,5 +151,8 @@
     "@angular-eslint/schematics:library": {
       "setParserOptionsProject": true
     }
+  },
+  "cli": {
+    "analytics": "72cac722-7e39-4ef7-9942-e52e4c3ee79e"
   }
 }

--- a/src/app/pets/pet-add/pet-add.component.html
+++ b/src/app/pets/pet-add/pet-add.component.html
@@ -50,21 +50,26 @@
           </div>
         </div>
   
-        <div class="form-group  has-feedback" [class.has-success]="birthDate.dirty && birthDate.valid"
-             [class.has-error]="birthDate.dirty && !birthDate.valid">
-          <label class="col-sm-2 control-label">Birth Date</label>
-          <div class="col-sm-10">
-            <input matInput [matDatepicker]="birthDateDatepicker" required [ngModel]="pet.birthDate | date:'yyyy-MM-dd'"
-                   name="birthDate" #birthDate="ngModel">
-            <mat-datepicker-toggle matSuffix [for]="birthDateDatepicker"></mat-datepicker-toggle>
-            <mat-datepicker #birthDateDatepicker></mat-datepicker>
-            <span class="glyphicon form-control-feedback" [class.glyphicon-ok]="birthDate.valid"
-                  [class.glyphicon-remove]="!birthDate.valid" aria-hidden="true"></span>
-            <span class="help-block"
-                  *ngIf="birthDate.dirty && birthDate.hasError('required')">BirthDate is required</span>
-  
-          </div>
-        </div>
+       <div class="form-group has-feedback" [class.has-success]="birthDate.dirty && birthDate.valid"
+     [class.has-error]="birthDate.dirty && !birthDate.valid">
+  <label class="col-sm-2 control-label">Birth Date</label>
+  <div class="col-sm-10">
+    <input matInput [matDatepicker]="birthDateDatepicker" [max]="maxDate" required 
+           [ngModel]="pet.birthDate | date:'yyyy-MM-dd'"
+           name="birthDate" #birthDate="ngModel">
+    
+    <mat-datepicker-toggle matSuffix [for]="birthDateDatepicker"></mat-datepicker-toggle>
+    <mat-datepicker #birthDateDatepicker></mat-datepicker>
+
+    <span class="help-block" *ngIf="birthDate.dirty && birthDate.errors?.matDatepickerMax">
+      Birth date cannot be in the future
+    </span>
+
+    <span class="help-block" *ngIf="birthDate.dirty && birthDate.hasError('required')">
+      BirthDate is required
+    </span>
+  </div>
+</div>
         <div class="control-group">
           <div class="form-group has-feedback" [class.has-success]="type.dirty && type.valid"
                [class.has-error]="type.dirty && !type.valid">

--- a/src/app/pets/pet-add/pet-add.component.ts
+++ b/src/app/pets/pet-add/pet-add.component.ts
@@ -44,6 +44,8 @@ export class PetAddComponent implements OnInit {
   petTypes: PetType[];
   addedSuccess = false;
   errorMessage: string;
+  maxDate=new Date();
+  
 
   constructor(private ownerService: OwnerService, private petService: PetService,
               private petTypeService: PetTypeService, private router: Router, private route: ActivatedRoute) {


### PR DESCRIPTION
I have updated the pet form to prevent users from selecting future birth dates.

Added [max] constraint to the Angular Material datepicker.

Added a validation message for the user.

This complements the backend fix in the REST repository.