### PR TITLE
fix page templates refresh issue

### DIFF
--- a/e2e/app.e2e-spec.ts
+++ b/e2e/app.e2e-spec.ts
@@ -6,6 +6,62 @@ test('displays the Petclinic welcome page', async ({ page }) => {
 });
 
 test('displays backend data on list pages', async ({ page }) => {
+  const vets = [
+    { id: 1, firstName: 'James', lastName: 'Carter', specialties: [] },
+    { id: 2, firstName: 'Helen', lastName: 'Leary', specialties: [{ id: 1, name: 'radiology' }] },
+    { id: 3, firstName: 'Linda', lastName: 'Douglas', specialties: [] },
+    { id: 4, firstName: 'Rafael', lastName: 'Ortega', specialties: [] },
+    { id: 5, firstName: 'Henry', lastName: 'Stevens', specialties: [] },
+    { id: 6, firstName: 'Sharon', lastName: 'Jenkins', specialties: [] }
+  ];
+  const petTypes = ['bird', 'cat', 'dog', 'hamster', 'lizard', 'snake']
+    .map((name, index) => ({ id: index + 1, name }));
+  const specialties = ['dentistry', 'radiology', 'surgery']
+    .map((name, index) => ({ id: index + 1, name }));
+  const owners = [
+    {
+      id: 1,
+      firstName: 'George',
+      lastName: 'Franklin',
+      address: '110 W. Liberty St.',
+      city: 'Madison',
+      telephone: '6085551023',
+      pets: []
+    },
+    {
+      id: 2,
+      firstName: 'Betty',
+      lastName: 'Davis',
+      address: '638 Cardinal Ave.',
+      city: 'Sun Prairie',
+      telephone: '6085551749',
+      pets: []
+    },
+    {
+      id: 4,
+      firstName: 'Harold',
+      lastName: 'Davis',
+      address: '563 Friendly St.',
+      city: 'Windsor',
+      telephone: '6085553198',
+      pets: []
+    }
+  ];
+
+  await page.route('**/petclinic/api/vets', route => route.fulfill({ json: vets }));
+  await page.route('**/petclinic/api/pettypes', route => route.fulfill({ json: petTypes }));
+  await page.route('**/petclinic/api/specialties', route => route.fulfill({ json: specialties }));
+  await page.route(
+    url => url.pathname.endsWith('/petclinic/api/owners'),
+    (route, request) => {
+      const lastName = new URL(request.url()).searchParams.get('lastName');
+      const response = lastName === null
+        ? owners
+        : owners.filter(owner => owner.lastName.startsWith(lastName));
+      return route.fulfill({ json: response });
+    }
+  );
+
   await page.goto('/petclinic/vets');
   await expect(page.locator('#vets tbody > tr')).toHaveCount(6);
   await expect(page.locator('#vets')).toContainText('James Carter');
@@ -13,17 +69,17 @@ test('displays backend data on list pages', async ({ page }) => {
 
   await page.goto('/petclinic/pettypes');
   await expect(page.locator('#pettypes tbody > tr')).toHaveCount(6);
-  const petTypes = await page.locator('#pettypes input').evaluateAll(
+  const renderedPetTypes = await page.locator('#pettypes input').evaluateAll(
     inputs => inputs.map(input => (input as HTMLInputElement).value)
   );
-  expect(petTypes).toEqual(expect.arrayContaining(['cat', 'dog']));
+  expect(renderedPetTypes).toEqual(expect.arrayContaining(['cat', 'dog']));
 
   await page.goto('/petclinic/specialties');
   await expect(page.locator('#specialties tbody > tr')).toHaveCount(3);
-  const specialties = await page.locator('#specialties input').evaluateAll(
+  const renderedSpecialties = await page.locator('#specialties input').evaluateAll(
     inputs => inputs.map(input => (input as HTMLInputElement).value)
   );
-  expect(specialties).toEqual(expect.arrayContaining(['dentistry', 'surgery']));
+  expect(renderedSpecialties).toEqual(expect.arrayContaining(['dentistry', 'surgery']));
 
   await page.goto('/petclinic/owners');
   await page.locator('#lastName').fill('Davis');

--- a/e2e/app.e2e-spec.ts
+++ b/e2e/app.e2e-spec.ts
@@ -4,3 +4,31 @@ test('displays the Petclinic welcome page', async ({ page }) => {
   await page.goto('/');
   await expect(page.getByRole('heading', { name: 'Welcome to Petclinic' })).toBeVisible();
 });
+
+test('displays backend data on list pages', async ({ page }) => {
+  await page.goto('/petclinic/vets');
+  await expect(page.locator('#vets tbody > tr')).toHaveCount(6);
+  await expect(page.locator('#vets')).toContainText('James Carter');
+  await expect(page.locator('#vets')).toContainText('radiology');
+
+  await page.goto('/petclinic/pettypes');
+  await expect(page.locator('#pettypes tbody > tr')).toHaveCount(6);
+  const petTypes = await page.locator('#pettypes input').evaluateAll(
+    inputs => inputs.map(input => (input as HTMLInputElement).value)
+  );
+  expect(petTypes).toEqual(expect.arrayContaining(['cat', 'dog']));
+
+  await page.goto('/petclinic/specialties');
+  await expect(page.locator('#specialties tbody > tr')).toHaveCount(3);
+  const specialties = await page.locator('#specialties input').evaluateAll(
+    inputs => inputs.map(input => (input as HTMLInputElement).value)
+  );
+  expect(specialties).toEqual(expect.arrayContaining(['dentistry', 'surgery']));
+
+  await page.goto('/petclinic/owners');
+  await page.locator('#lastName').fill('Davis');
+  await page.getByRole('button', { name: 'Find Owner' }).click();
+  await expect(page.getByRole('link', { name: 'Betty Davis' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Harold Davis' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'George Franklin' })).toHaveCount(0);
+});

--- a/src/app/owners/owner-list/owner-list.component.ts
+++ b/src/app/owners/owner-list/owner-list.component.ts
@@ -20,7 +20,7 @@
  * @author Vitaliy Fedoriv
  */
 
-import {Component, OnInit} from '@angular/core';
+import {ChangeDetectorRef, Component, inject, OnInit} from '@angular/core';
 import {OwnerService} from '../owner.service';
 import {Owner} from '../owner';
 import {Router} from '@angular/router';
@@ -33,6 +33,8 @@ import { finalize } from 'rxjs/operators';
   styleUrls: ['./owner-list.component.css']
 })
 export class OwnerListComponent implements OnInit {
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+
   errorMessage: string;
   lastName: string;
   owners: Owner[];
@@ -47,6 +49,7 @@ export class OwnerListComponent implements OnInit {
     this.ownerService.getOwners().pipe(
       finalize(() => {
         this.isOwnersDataReceived = true;
+        this.changeDetectorRef.markForCheck();
       })
     ).subscribe(
       owners => this.owners = owners,
@@ -67,6 +70,7 @@ export class OwnerListComponent implements OnInit {
       if (lastName === '')
       {
       this.ownerService.getOwners()
+      .pipe(finalize(() => this.changeDetectorRef.markForCheck()))
       .subscribe(
             (owners) => {
              this.owners = owners;
@@ -75,6 +79,7 @@ export class OwnerListComponent implements OnInit {
       if (lastName !== '')
       {
       this.ownerService.searchOwners(lastName)
+      .pipe(finalize(() => this.changeDetectorRef.markForCheck()))
       .subscribe(
       (owners) => {
 

--- a/src/app/pettypes/pettype-list/pettype-list.component.ts
+++ b/src/app/pettypes/pettype-list/pettype-list.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {ChangeDetectorRef, Component, inject, OnInit} from '@angular/core';
 import {PetType} from '../pettype';
 import {Router} from '@angular/router';
 import {PetTypeService} from '../pettype.service';
@@ -12,6 +12,8 @@ import { finalize } from 'rxjs/operators';
   styleUrls: ['./pettype-list.component.css']
 })
 export class PettypeListComponent implements OnInit {
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+
   pettypes: PetType[];
   errorMessage: string;
   responseStatus: number;
@@ -26,6 +28,7 @@ export class PettypeListComponent implements OnInit {
     this.pettypeService.getPetTypes().pipe(
       finalize(() => {
         this.isPetTypesDataReceived = true;
+        this.changeDetectorRef.markForCheck();
       })
     ).subscribe(
       pettypes => this.pettypes = pettypes,
@@ -34,7 +37,9 @@ export class PettypeListComponent implements OnInit {
   }
 
   deletePettype(pettype: PetType) {
-    this.pettypeService.deletePetType(pettype.id.toString()).subscribe(
+    this.pettypeService.deletePetType(pettype.id.toString()).pipe(
+      finalize(() => this.changeDetectorRef.markForCheck())
+    ).subscribe(
       response => {
         this.responseStatus = response;
         this.pettypes = this.pettypes.filter(currentItem => !(currentItem.id === pettype.id));

--- a/src/app/specialties/specialty-list/specialty-list.component.ts
+++ b/src/app/specialties/specialty-list/specialty-list.component.ts
@@ -20,7 +20,7 @@
  * @author Vitaliy Fedoriv
  */
 
-import {Component, OnInit} from '@angular/core';
+import {ChangeDetectorRef, Component, inject, OnInit} from '@angular/core';
 import {Specialty} from '../specialty';
 import {SpecialtyService} from '../specialty.service';
 import {Router} from '@angular/router';
@@ -33,6 +33,8 @@ import { finalize } from 'rxjs/operators';
   styleUrls: ['./specialty-list.component.css']
 })
 export class SpecialtyListComponent implements OnInit {
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+
   specialties: Specialty[];
   errorMessage: string;
   responseStatus: number;
@@ -47,6 +49,7 @@ export class SpecialtyListComponent implements OnInit {
     this.specService.getSpecialties().pipe(
       finalize(() => {
         this.isSpecialitiesDataReceived = true;
+        this.changeDetectorRef.markForCheck();
       })
     ).subscribe(
       specialties => this.specialties = specialties,
@@ -54,7 +57,9 @@ export class SpecialtyListComponent implements OnInit {
   }
 
   deleteSpecialty(specialty: Specialty) {
-    this.specService.deleteSpecialty(specialty.id.toString()).subscribe(
+    this.specService.deleteSpecialty(specialty.id.toString()).pipe(
+      finalize(() => this.changeDetectorRef.markForCheck())
+    ).subscribe(
       response => {
         this.responseStatus = response;
         this.specialties = this.specialties.filter(currentItem => !(currentItem.id === specialty.id));

--- a/src/app/vets/vet-list/vet-list.component.ts
+++ b/src/app/vets/vet-list/vet-list.component.ts
@@ -20,7 +20,7 @@
  * @author Vitaliy Fedoriv
  */
 
-import {Component, OnInit} from '@angular/core';
+import {ChangeDetectorRef, Component, inject, OnInit} from '@angular/core';
 import {Vet} from '../vet';
 import {VetService} from '../vet.service';
 import {Router} from '@angular/router';
@@ -33,6 +33,8 @@ import { finalize } from 'rxjs/operators';
   styleUrls: ['./vet-list.component.css']
 })
 export class VetListComponent implements OnInit {
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+
   vets: Vet[];
   errorMessage: string;
   responseStatus: number;
@@ -46,6 +48,7 @@ export class VetListComponent implements OnInit {
     this.vetService.getVets().pipe(
       finalize(() => {
         this.isVetDataReceived = true;
+        this.changeDetectorRef.markForCheck();
       })
     ).subscribe(
       vets => this.vets = vets,
@@ -53,7 +56,9 @@ export class VetListComponent implements OnInit {
   }
 
   deleteVet(vet: Vet) {
-    this.vetService.deleteVet(vet.id.toString()).subscribe(
+    this.vetService.deleteVet(vet.id.toString()).pipe(
+      finalize(() => this.changeDetectorRef.markForCheck())
+    ).subscribe(
       response => {
         this.responseStatus = response;
         this.vets = this.vets.filter(currentItem => !(currentItem.id === vet.id));


### PR DESCRIPTION
Fixed rendering regression.

Angular 22 uses zoneless change detection by default.
HTTP subscriptions updated component fields correctly, but the templates were not automatically refreshed.